### PR TITLE
Add support for <MIM

### DIFF
--- a/src/MyChar.cpp
+++ b/src/MyChar.cpp
@@ -218,10 +218,9 @@ void PutMyChar(int fx, int fy)
 
 	// Draw player
 	RECT rect = gMC.rect;
-#ifdef ENABLE_MIM
 	rect.top += 32 * gMIMCurrentNum;
 	rect.bottom += 32 * gMIMCurrentNum;
-#else
+#ifndef ENABLE_MIM_DISABLE_EQUIP_40_GRAPHICS
 	if (gMC.equip & 0x40)
 	{
 		rect.top += 32;

--- a/src/MyChar.cpp
+++ b/src/MyChar.cpp
@@ -218,11 +218,16 @@ void PutMyChar(int fx, int fy)
 
 	// Draw player
 	RECT rect = gMC.rect;
+#ifdef ENABLE_MIM
+	rect.top += 32 * gMIMCurrentNum;
+	rect.bottom += 32 * gMIMCurrentNum;
+#else
 	if (gMC.equip & 0x40)
 	{
 		rect.top += 32;
 		rect.bottom += 32;
 	}
+#endif
 
 	PutBitmap3(&grcGame, SubpixelToScreenCoord(gMC.x - gMC.view.front) - SubpixelToScreenCoord(fx), SubpixelToScreenCoord(gMC.y - gMC.view.top) - SubpixelToScreenCoord(fy), &rect, SURFACE_ID_MY_CHAR);
 

--- a/src/NpcAct100.cpp
+++ b/src/NpcAct100.cpp
@@ -838,10 +838,9 @@ void ActNpc111(NPCHAR *npc)
 	else
 		npc->rect = rcRight[npc->ani_no];
 
-#ifdef ENABLE_MIM
 	npc->rect.top += 32 * gMIMCurrentNum;
 	npc->rect.bottom += 32 * gMIMCurrentNum;
-#else
+#ifndef ENABLE_MIM_DISABLE_EQUIP_40_GRAPHICS
 	if (gMC.equip & 0x40)
 	{
 		npc->rect.top += 32;
@@ -919,10 +918,9 @@ void ActNpc112(NPCHAR *npc)
 	else
 		npc->rect = rcRight[npc->ani_no];
 
-#ifndef ENABLE_MIM
 	npc->rect.top += 32 * gMIMCurrentNum;
 	npc->rect.bottom += 32 * gMIMCurrentNum;
-#else
+#ifndef ENABLE_MIM_DISABLE_EQUIP_40_GRAPHICS
 	if (gMC.equip & 0x40)
 	{
 		npc->rect.top += 32;

--- a/src/NpcAct100.cpp
+++ b/src/NpcAct100.cpp
@@ -9,6 +9,7 @@
 #include "MyChar.h"
 #include "NpChar.h"
 #include "Sound.h"
+#include "TextScr.h"
 
 // Grate
 void ActNpc100(NPCHAR *npc)
@@ -837,11 +838,16 @@ void ActNpc111(NPCHAR *npc)
 	else
 		npc->rect = rcRight[npc->ani_no];
 
+#ifdef ENABLE_MIM
+	npc->rect.top += 32 * gMIMCurrentNum;
+	npc->rect.bottom += 32 * gMIMCurrentNum;
+#else
 	if (gMC.equip & 0x40)
 	{
 		npc->rect.top += 32;
 		npc->rect.bottom += 32;
 	}
+#endif
 
 	if (npc->act_no == 4)
 	{
@@ -913,11 +919,16 @@ void ActNpc112(NPCHAR *npc)
 	else
 		npc->rect = rcRight[npc->ani_no];
 
+#ifndef ENABLE_MIM
+	npc->rect.top += 32 * gMIMCurrentNum;
+	npc->rect.bottom += 32 * gMIMCurrentNum;
+#else
 	if (gMC.equip & 0x40)
 	{
 		npc->rect.top += 32;
 		npc->rect.bottom += 32;
 	}
+#endif
 
 	if (npc->act_no == 1)
 	{

--- a/src/NpcAct140.cpp
+++ b/src/NpcAct140.cpp
@@ -1256,10 +1256,8 @@ void ActNpc150(NPCHAR *npc)
 	else
 		npc->rect = rcRight[npc->ani_no];
 
-#ifdef ENABLE_MIM
 	npc->rect.top += 32 * gMIMCurrentNum;
 	npc->rect.bottom += 32 * gMIMCurrentNum;
-#endif
 
 	if (npc->act_no == 21)
 	{
@@ -1269,6 +1267,7 @@ void ActNpc150(NPCHAR *npc)
 			++npc->rect.left;
 	}
 
+	// In theory this should be disabled by ENABLE_MIM_DISABLE_EQUIP_40_GRAPHICS, but the original mod doesn't do that (probably a bug tbh) so we don't do it either in order to make it so its behaviour is reproduced exactly with ENABLE_MIM_DISABLE_EQUIP_40_GRAPHICS
 	if (gMC.equip & 0x40)
 	{
 		npc->rect.top += 32;

--- a/src/NpcAct140.cpp
+++ b/src/NpcAct140.cpp
@@ -11,6 +11,7 @@
 #include "MyChar.h"
 #include "NpChar.h"
 #include "Sound.h"
+#include "TextScr.h"
 #include "Triangle.h"
 
 // Toroko (frenzied)
@@ -1254,6 +1255,11 @@ void ActNpc150(NPCHAR *npc)
 		npc->rect = rcLeft[npc->ani_no];
 	else
 		npc->rect = rcRight[npc->ani_no];
+
+#ifdef ENABLE_MIM
+	npc->rect.top += 32 * gMIMCurrentNum;
+	npc->rect.bottom += 32 * gMIMCurrentNum;
+#endif
 
 	if (npc->act_no == 21)
 	{

--- a/src/TextScr.cpp
+++ b/src/TextScr.cpp
@@ -53,6 +53,10 @@ RECT gRect_line = {0, 0, 216, 16};
 static unsigned long nod_color;
 #endif
 
+#ifdef ENABLE_MIM
+unsigned int gMIMCurrentNum = 0;
+#endif
+
 //Initialize and end tsc
 BOOL InitTextScript2()
 {
@@ -599,6 +603,13 @@ int TextScriptProc()
 						gTS.face = 0;
 						bExit = TRUE;
 					}
+#ifdef ENABLE_MIM
+					else if (IS_COMMAND('M','I','M'))
+					{
+						gMIMCurrentNum = GetTextScriptNo(gTS.p_read + 4);
+						gTS.p_read += 8;
+					}
+#endif
 					else if (IS_COMMAND('L','I','+'))
 					{
 						x = GetTextScriptNo(gTS.p_read + 4);

--- a/src/TextScr.cpp
+++ b/src/TextScr.cpp
@@ -53,9 +53,7 @@ RECT gRect_line = {0, 0, 216, 16};
 static unsigned long nod_color;
 #endif
 
-#ifdef ENABLE_MIM
 unsigned int gMIMCurrentNum = 0;
-#endif
 
 //Initialize and end tsc
 BOOL InitTextScript2()
@@ -603,13 +601,11 @@ int TextScriptProc()
 						gTS.face = 0;
 						bExit = TRUE;
 					}
-#ifdef ENABLE_MIM
 					else if (IS_COMMAND('M','I','M'))
 					{
 						gMIMCurrentNum = GetTextScriptNo(gTS.p_read + 4);
 						gTS.p_read += 8;
 					}
-#endif
 					else if (IS_COMMAND('L','I','+'))
 					{
 						x = GetTextScriptNo(gTS.p_read + 4);

--- a/src/TextScr.h
+++ b/src/TextScr.h
@@ -65,7 +65,5 @@ void PutTextScript();
 int TextScriptProc();
 void RestoreTextScript();
 
-#ifndef ENABLE_MIM
 /// Contains the latest value given through <MIM
 extern unsigned int gMIMCurrentNum;
-#endif

--- a/src/TextScr.h
+++ b/src/TextScr.h
@@ -64,3 +64,8 @@ void StopTextScript();
 void PutTextScript();
 int TextScriptProc();
 void RestoreTextScript();
+
+#ifndef ENABLE_MIM
+/// Contains the latest value given through <MIM
+extern unsigned int gMIMCurrentNum;
+#endif


### PR DESCRIPTION
This adds support for the <MIM command, based on [BL's support for it](https://github.com/taedixon/boosters-lab/blob/master/hacks/TSC%20modifications/unobtrusive_infinite_mimigamask.xml) (except it doesn't use part of gFlagNPC to contain its variable)