### PR TITLE
Add "Creepy Curly" NPC 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,8 @@ add_executable(CSE2
 	src/NpcAct300.cpp
 	src/NpcAct320.cpp
 	src/NpcAct340.cpp
+	src/NpcAct360.cpp
+	src/NpcAct380.cpp
 	src/NpChar.cpp
 	src/NpChar.h
 	src/NpcHit.cpp

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ SOURCES = \
 	src/NpcAct300 \
 	src/NpcAct320 \
 	src/NpcAct340 \
+	src/NpcAct360 \
+	src/NpcAct380 \
 	src/NpChar \
 	src/NpcHit \
 	src/NpcTbl \

--- a/src/NpcAct.h
+++ b/src/NpcAct.h
@@ -363,3 +363,30 @@ void ActNpc357(NPCHAR *npc);
 void ActNpc358(NPCHAR *npc);
 void ActNpc359(NPCHAR *npc);
 void ActNpc360(NPCHAR *npc);
+void ActNpc361(NPCHAR *npc);
+void ActNpc362(NPCHAR *npc);
+void ActNpc363(NPCHAR *npc);
+void ActNpc364(NPCHAR *npc);
+void ActNpc365(NPCHAR *npc);
+void ActNpc366(NPCHAR *npc);
+void ActNpc367(NPCHAR *npc);
+void ActNpc368(NPCHAR *npc);
+void ActNpc369(NPCHAR *npc);
+
+// Reserved for future CS+ updates
+/*
+void ActNpc370(NPCHAR *npc);
+void ActNpc371(NPCHAR *npc);
+void ActNpc370(NPCHAR *npc);
+void ActNpc372(NPCHAR *npc);
+void ActNpc373(NPCHAR *npc);
+void ActNpc374(NPCHAR *npc);
+void ActNpc375(NPCHAR *npc);
+void ActNpc376(NPCHAR *npc);
+void ActNpc377(NPCHAR *npc);
+void ActNpc378(NPCHAR *npc);
+void ActNpc379(NPCHAR *npc);
+void ActNpc380(NPCHAR *npc);
+*/
+
+void ActNpc381(NPCHAR *npc);

--- a/src/NpcAct100.cpp
+++ b/src/NpcAct100.cpp
@@ -1509,6 +1509,9 @@ void ActNpc117(NPCHAR *npc)
 // Curly (boss)
 void ActNpc118(NPCHAR *npc)
 {
+#ifdef ENABLE_OVERRIDE_NPC_118_TO_CREEPY_CURLY
+	return ActNpc381(npc);
+#endif
 	RECT rcLeft[9] = {
 		{0, 32, 32, 56},
 		{32, 32, 64, 56},

--- a/src/NpcAct360.cpp
+++ b/src/NpcAct360.cpp
@@ -1,0 +1,49 @@
+#include "NpcAct.h"
+#include "NpChar.h"
+
+// CS+ NPCs
+
+void ActNpc361(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc362(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc363(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc364(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc365(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc366(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc367(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc368(NPCHAR *npc)
+{
+	// TBD
+}
+
+void ActNpc369(NPCHAR *npc)
+{
+	// TBD
+}

--- a/src/NpcAct380.cpp
+++ b/src/NpcAct380.cpp
@@ -1,0 +1,55 @@
+#include "NpcAct.h"
+#include "NpChar.h"
+#include "MyChar.h"
+
+/// "Follow" a coordinate by getting closer to it
+/// Returns currentX + (1/32) * (targetX - currentX), thusly getting currentX 1/32th closer to targetX
+inline int followCoordinate(int currentX, int targetX)
+{
+	return (targetX + 31 * currentX) >> 5;
+}
+
+/// Creepy Curly
+/// NPC that follows the player or an NPC
+void ActNpc381(NPCHAR *npc)
+{
+	npc->direct = 0;
+	if (npc->act_no > 200)
+	{
+		// Follow the first NPC for which act_no == this->act_no - 1
+		for (size_t i = 0; i < NPC_MAX; ++i)
+		{
+			NPCHAR *checkedNpc = &gNPC[i];
+			if ((checkedNpc->cond & 0x80) && checkedNpc->act_no == npc->act_no - 1)
+			{
+				NPCHAR *matchedNpc = checkedNpc;
+				if (npc->x <= matchedNpc->x)
+					npc->direct = 2;
+
+				npc->x = followCoordinate(npc->x, matchedNpc->x);
+				npc->y = followCoordinate(npc->y, matchedNpc->y);
+			}
+		}
+	}
+	else
+	{
+		// Follow the player
+		if (npc->x <= gMC.x)
+			npc->direct = 2;
+		npc->x = followCoordinate(npc->x, gMC.x);
+		npc->y = followCoordinate(npc->y, gMC.y);
+	}
+
+	int animationIterator = ++npc->act_wait / 3 & 3;
+
+	if (animationIterator == 2)
+		animationIterator = 0;
+
+	if (animationIterator == 3)
+		animationIterator = 2;
+
+	npc->rect.left = animationIterator * 16;
+	npc->rect.right = npc->rect.left + 16;
+	npc->rect.top = npc->direct * 8 + 96;
+	npc->rect.bottom = npc->rect.top + 16;
+}

--- a/src/NpcTbl.cpp
+++ b/src/NpcTbl.cpp
@@ -72,7 +72,7 @@ void ReleaseNpcTable()
 }
 
 // Npc function table
-NPCFUNCTION gpNpcFuncTbl[361] =
+NPCFUNCTION gpNpcFuncTbl[382] =
 {
 	ActNpc000,
 	ActNpc001,
@@ -435,4 +435,25 @@ NPCFUNCTION gpNpcFuncTbl[361] =
 	ActNpc358,
 	ActNpc359,
 	ActNpc360,
+	ActNpc361,
+	ActNpc362,
+	ActNpc363,
+	ActNpc364,
+	ActNpc365,
+	ActNpc366,
+	ActNpc367,
+	ActNpc368,
+	ActNpc369,
+	nullptr,	// 370
+	nullptr,	// 371
+	nullptr,	// 372
+	nullptr,	// 373
+	nullptr,	// 374
+	nullptr,	// 375
+	nullptr,	// 376
+	nullptr,	// 377
+	nullptr,	// 378
+	nullptr,	// 379
+	nullptr,	// 380
+	ActNpc381,
 };


### PR DESCRIPTION
This also makes it so there is elemental support for CS+'s added NPCs
This adds NpcAct360.cpp (with stubs for CS+'s added NPCs) and NpcAct380.cpp (with the "Creepy Curly" NPC as NPC 381)