### PR TITLE
Add warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	message(STATUS "Compiling with clang")
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	# Using GCC
 	set(COMPILER_IS_GCC true)
 	message(STATUS "Compiling with gcc")
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 	# Using Intel C++
 	set(COMPILER_IS_ICC true)
 	message(STATUS "Compiling with ICC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,13 @@ set(ASSETS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/assets")
 
 option(JAPANESE "Enable the Japanese-language build" OFF)
 option(FIX_BUGS "Fix various bugs in the game" OFF)
-option(WARNINGS "Enable common warnings" OFF)
-option(ALL_WARNINGS "Enable ALL warnings (clang/MSVC-only)" OFF)
-option(FATAL_WARNINGS "Stop compilation on any warnings" OFF)
 option(DEBUG_SAVE "Re-enable the ability to drag-and-drop save files onto the window" OFF)
-option(FORCE_LOCAL_LIBS "Compile the built-in versions of SDL2, FreeType, and FLTK instead of using the system-provided ones" OFF)
 set(RENDERER "SDLTexture" CACHE STRING "Which renderer the game should use: 'OpenGL3' for an OpenGL 3.2 renderer, 'SDLTexture' for SDL2's hardware-accelerated Texture API, 'SDLSurface' for SDL2's software-rendered Surface API, or 'Software' for a handwritten software renderer")
+
+option(WARNINGS "Enable common compiler warnings (for gcc-compatible compilers and MSVC only)" OFF)
+option(ALL_WARNINGS "Enable ALL compiler warnings (for clang and MSVC only)" OFF)
+option(FATAL_WARNINGS "Stop compilation on any compiler warning (for gcc-compatible compilers and MSVC only)" OFF)
+option(FORCE_LOCAL_LIBS "Compile the built-in versions of SDL2, FreeType, and FLTK instead of using the system-provided ones" OFF)
 
 project(CSE2 LANGUAGES C CXX)
 
@@ -323,10 +324,8 @@ if (FATAL_WARNINGS)
 
 	if (MSVC)
 		target_compile_options(CSE2 PRIVATE /WX)
-		target_compile_options(bin2h PRIVATE /WX)
 	elseif(COMPILER_IS_GCC_COMPATIBLE)
 		target_compile_options(CSE2 PRIVATE -Werror)
-		target_compile_options(bin2h PRIVATE -Werror)
 	else()
 		message(WARNING "Could not activate fatal warnings ! (Unsupported compiler)")
 	endif()
@@ -512,6 +511,11 @@ endif()
 ##
 # DoConfig
 ##
+
+# Set warning options for DoConfig
+set(WARNINGS ${WARNINGS} FORCE BOOL)
+set(ALL_WARNINGS ${ALL_WARNINGS} FORCE BOOL)
+set(FATAL_WARNINGS ${FATAL_WARNINGS} FORCE BOOL)
 
 add_subdirectory("DoConfig")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 set(BUILD_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/game")
 set(ASSETS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/assets")
 
-option(JAPANESE "Enable the Japanese-language build" OFF)
+option(JAPANESE "Enable the Japanese-language build (instead of the unofficial Aeon Genesis English translation)" OFF)
 option(FIX_BUGS "Fix various bugs in the game" OFF)
 option(DEBUG_SAVE "Re-enable the ability to drag-and-drop save files onto the window" OFF)
 set(RENDERER "SDLTexture" CACHE STRING "Which renderer the game should use: 'OpenGL3' for an OpenGL 3.2 renderer, 'SDLTexture' for SDL2's hardware-accelerated Texture API, 'SDLSurface' for SDL2's software-rendered Surface API, or 'Software' for a handwritten software renderer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ set(RENDERER "SDLTexture" CACHE STRING "Which renderer the game should use: 'Ope
 
 project(CSE2 LANGUAGES C CXX)
 
+message(STATUS "Compiler ID : ${CMAKE_CXX_COMPILER_ID}")
+
 # Has to be placed after "project()"
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	# Using Clang (this is a match so that we also get "AppleClang" which is the Apple-provided Clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,38 @@ set(ASSETS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/assets")
 
 option(JAPANESE "Enable the Japanese-language build" OFF)
 option(FIX_BUGS "Fix various bugs in the game" OFF)
+option(WARNINGS "Enable common warnings" OFF)
+option(ALL_WARNINGS "Enable ALL warnings (clang/MSVC-only)" OFF)
+option(FATAL_WARNINGS "Stop compilation on any warnings" OFF)
 option(DEBUG_SAVE "Re-enable the ability to drag-and-drop save files onto the window" OFF)
 option(FORCE_LOCAL_LIBS "Compile the built-in versions of SDL2, FreeType, and FLTK instead of using the system-provided ones" OFF)
 set(RENDERER "SDLTexture" CACHE STRING "Which renderer the game should use: 'OpenGL3' for an OpenGL 3.2 renderer, 'SDLTexture' for SDL2's hardware-accelerated Texture API, 'SDLSurface' for SDL2's software-rendered Surface API, or 'Software' for a handwritten software renderer")
 
 project(CSE2 LANGUAGES C CXX)
+
+# Has to be placed after "project()"
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	# Using Clang (this is a match so that we also get "AppleClang" which is the Apple-provided Clang
+	set(COMPILER_IS_CLANG true)
+	message(STATUS "Compiling with clang")
+endif()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	# Using GCC
+	set(COMPILER_IS_GCC true)
+	message(STATUS "Compiling with gcc")
+endif()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+	# Using Intel C++
+	set(COMPILER_IS_ICC true)
+	message(STATUS "Compiling with ICC")
+endif()
+
+if (COMPILER_IS_CLANG OR COMPILER_IS_GCC OR COMPILER_IS_ICC)
+	set(COMPILER_IS_GCC_COMPATIBLE true)
+	message(STATUS "Compiling with a GCC-compatible compiler")
+endif()
 
 if(MSVC)
 	# Statically-link the CRT (vcpkg static libs do this)
@@ -247,6 +274,62 @@ if(DEBUG_SAVE)
 	target_compile_definitions(CSE2 PRIVATE DEBUG_SAVE)
 endif()
 
+if (WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		# Force to always compile with /W4 on MSVC
+
+		# Can't do this with target_compile_options
+		# if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		# 	string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		# else()
+		# 	target_compile_options(CSE2 PRIVATE /W4)
+		# endif()
+
+		target_compile_options(CSE2 PRIVATE /W4)
+	elseif(COMPILER_IS_GCC_COMPATIBLE)
+		target_compile_options(CSE2 PRIVATE -Wall -Wextra -pedantic)
+	else()
+		message(WARNING "Could not activate warnings ! (Unsupported compiler)")
+	endif()
+endif()
+
+if (ALL_WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		# Force to always compile with /Wall on MSVC
+
+		# Can't do this with target_compile_options
+		# if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		# 	string(REGEX REPLACE "/W[0-4]" "/Wall" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		# else()
+		# 	target_compile_options(CSE2 PRIVATE /Wall)
+		# endif()
+
+		target_compile_options(CSE2 PRIVATE /Wall)
+	elseif(COMPILER_IS_CLANG)
+		target_compile_options(CSE2 PRIVATE -Weverything)
+	else()
+		message(WARNING "Could not activate all warnings ! (Unsupported compiler)")
+	endif()
+endif()
+
+if (FATAL_WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		target_compile_options(CSE2 PRIVATE /WX)
+		target_compile_options(bin2h PRIVATE /WX)
+	elseif(COMPILER_IS_GCC_COMPATIBLE)
+		target_compile_options(CSE2 PRIVATE -Werror)
+		target_compile_options(bin2h PRIVATE -Werror)
+	else()
+		message(WARNING "Could not activate fatal warnings ! (Unsupported compiler)")
+	endif()
+endif()
+
 if(RENDERER MATCHES "OpenGL3")
 	target_sources(CSE2 PRIVATE "src/Backends/Rendering/OpenGL3.cpp")
 elseif(RENDERER MATCHES "SDLTexture")
@@ -281,6 +364,9 @@ ExternalProject_Add(bin2h
 	CMAKE_ARGS
 		-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 		-DCMAKE_BUILD_TYPE=Release
+		-DWARNINGS=${WARNINGS}
+		-DALL_WARNINGS=${ALL_WARNINGS}
+		-DFATAL_WARNINGS=${FATAL_WARNINGS}
 	INSTALL_COMMAND
 		${CMAKE_COMMAND} --build . --config Release --target install
 )

--- a/DoConfig/CMakeLists.txt
+++ b/DoConfig/CMakeLists.txt
@@ -8,7 +8,87 @@ option(FORCE_LOCAL_LIBS "Compile the built-in version of FLTK instead of using t
 
 project(DoConfig LANGUAGES CXX)
 
+message(STATUS "Compiler ID : ${CMAKE_CXX_COMPILER_ID}")
+
+# Has to be placed after "project()"
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	# Using Clang (this is a match so that we also get "AppleClang" which is the Apple-provided Clang
+	set(COMPILER_IS_CLANG true)
+	message(STATUS "Compiling with clang")
+endif()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	# Using GCC
+	set(COMPILER_IS_GCC true)
+	message(STATUS "Compiling with gcc")
+endif()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+	# Using Intel C++
+	set(COMPILER_IS_ICC true)
+	message(STATUS "Compiling with ICC")
+endif()
+
+if (COMPILER_IS_CLANG OR COMPILER_IS_GCC OR COMPILER_IS_ICC)
+	set(COMPILER_IS_GCC_COMPATIBLE true)
+	message(STATUS "Compiling with a GCC-compatible compiler")
+endif()
+
 add_executable(DoConfig "DoConfig.cpp" "icon.rc")
+
+if (WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		# Force to always compile with /W4 on MSVC
+
+		# Can't do this with target_compile_options
+		# if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		# 	string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		# else()
+		# 	target_compile_options(CSE2 PRIVATE /W4)
+		# endif()
+
+		target_compile_options(DoConfig PRIVATE /W4)
+	elseif(COMPILER_IS_GCC_COMPATIBLE)
+		target_compile_options(DoConfig PRIVATE -Wall -Wextra -pedantic)
+	else()
+		message(WARNING "Could not activate warnings ! (Unsupported compiler)")
+	endif()
+endif()
+
+if (ALL_WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		# Force to always compile with /Wall on MSVC
+
+		# Can't do this with target_compile_options
+		# if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		# 	string(REGEX REPLACE "/W[0-4]" "/Wall" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		# else()
+		# 	target_compile_options(CSE2 PRIVATE /Wall)
+		# endif()
+
+		target_compile_options(DoConfig PRIVATE /Wall)
+	elseif(COMPILER_IS_CLANG)
+		target_compile_options(DoConfig PRIVATE -Weverything)
+	else()
+		message(WARNING "Could not activate all warnings ! (Unsupported compiler)")
+	endif()
+endif()
+
+if (FATAL_WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		target_compile_options(DoConfig PRIVATE /WX)
+	elseif(COMPILER_IS_GCC_COMPATIBLE)
+		target_compile_options(DoConfig PRIVATE -Werror)
+	else()
+		message(WARNING "Could not activate fatal warnings ! (Unsupported compiler)")
+	endif()
+endif()
 
 # Windows tweak
 if(WIN32)

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,23 @@ ifeq ($(DEBUG_SAVE), 1)
 	CXXFLAGS += -DDEBUG_SAVE
 endif
 
+ifeq ($(WARNINGS), 1)
+	CXXFLAGS += -Wall -Wextra -pedantic
+endif
+
+ifeq ($(ALL_WARNINGS), 1)
+	ifneq ($(findstring clang,$(CXX),)
+		# Use clang-specific flag -Weverything
+		CXXFLAGS += -Weverything
+	else
+		@echo Couldn\'t activate all warnings (Unsupported compiler)
+	endif
+endif
+
+ifeq ($(FATAL_WARNINGS), 1)
+	CXXFLAGS += -Werror
+endif
+
 CXXFLAGS += -std=c++98 -MMD -MP -MF $@.d `$(PKG_CONFIG) sdl2 --cflags` `$(PKG_CONFIG) freetype2 --cflags`
 
 ifeq ($(STATIC), 1)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Name | Function
 `-DFIX_BUGS=ON` | Fix various bugs in the game
 `-DDEBUG_SAVE=ON` | Re-enable the ability to drag-and-drop save files onto the window
 `-DFORCE_LOCAL_LIBS=ON` | Compile the built-in versions of SDL2, FreeType, and FLTK instead of using the system-provided ones
+`-DWARNINGS=ON` | Enable common warnings
+`-DALL_WARNINGS=ON` | Enable ALL warnings (clang/MSVC-only)
+`-DFATAL_WARNINGS=ON` | Make all warnings errors
 `-DRENDERER=OpenGL3` | Use the hardware-accelerated OpenGL 3.2 renderer
 `-DRENDERER=SDLTexture` | Use the hardware-accelerated SDL2 Texture API renderer (default)
 `-DRENDERER=SDLSurface` | Use the software-rendered SDL2 Surface API renderer
@@ -92,6 +95,9 @@ Name | Function
 `FIX_BUGS=1` | Fix various bugs in the game
 `WINDOWS=1` | Build for Windows
 `DEBUG_SAVE=1` | Re-enable the ability to drag-and-drop save files onto the window
+`WARNINGS=1` | Enable common warnings
+`ALL_WARNINGS=1` | Enable ALL warnings (clang/MSVC only)
+`FATAL_WARNINGS=1` | Make all warnings errors
 `RENDERER=OpenGL3` | Use the hardware-accelerated OpenGL 3.2 renderer
 `RENDERER=SDLTexture` | Use the hardware-accelerated SDL2 Texture API renderer (default)
 `RENDERER=SDLSurface` | Use the software-rendered SDL2 Surface API renderer

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Name | Function
 `-DJAPANESE=ON` | Enable the Japanese-language build (instead of the unofficial Aeon Genesis English translation)
 `-DFIX_BUGS=ON` | Fix various bugs in the game
 `-DDEBUG_SAVE=ON` | Re-enable the ability to drag-and-drop save files onto the window
-`-DFORCE_LOCAL_LIBS=ON` | Compile the built-in versions of SDL2, FreeType, and FLTK instead of using the system-provided ones
-`-DWARNINGS=ON` | Enable common warnings
-`-DALL_WARNINGS=ON` | Enable ALL warnings (clang/MSVC-only)
-`-DFATAL_WARNINGS=ON` | Make all warnings errors
 `-DRENDERER=OpenGL3` | Use the hardware-accelerated OpenGL 3.2 renderer
 `-DRENDERER=SDLTexture` | Use the hardware-accelerated SDL2 Texture API renderer (default)
 `-DRENDERER=SDLSurface` | Use the software-rendered SDL2 Surface API renderer
 `-DRENDERER=Software` | Use the handwritten software renderer
+`-DWARNINGS=ON` | Enable common compiler warnings (for gcc-compatible compilers and MSVC only)
+`-DALL_WARNINGS=ON` | Enable ALL compiler warnings (for clang and MSVC only)
+`-DFATAL_WARNINGS=ON` | Stop compilation on any compiler warning (for gcc-compatible compilers and MSVC only)
+`-DFORCE_LOCAL_LIBS=ON` | Compile the built-in versions of SDL2, FreeType, and FLTK instead of using the system-provided ones
 
 Then compile CSE2 with this command:
 

--- a/bin2h/CMakeLists.txt
+++ b/bin2h/CMakeLists.txt
@@ -6,6 +6,14 @@ endif()
 
 project(bin2h LANGUAGES C)
 
+add_executable(bin2h "bin2h.c")
+
+set_target_properties(bin2h PROPERTIES
+	C_STANDARD 90
+	C_STANDARD_REQUIRED ON
+	C_EXTENSIONS OFF
+)
+
 # Has to be placed after "project()"
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	# Using Clang (this is a match so that we also get "AppleClang" which is the Apple-provided Clang
@@ -13,13 +21,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	message(STATUS "Compiling with clang")
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	# Using GCC
 	set(COMPILER_IS_GCC true)
 	message(STATUS "Compiling with gcc")
 endif()
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 	# Using Intel C++
 	set(COMPILER_IS_ICC true)
 	message(STATUS "Compiling with ICC")
@@ -29,15 +37,6 @@ if (COMPILER_IS_CLANG OR COMPILER_IS_GCC OR COMPILER_IS_ICC)
 	set(COMPILER_IS_GCC_COMPATIBLE true)
 	message(STATUS "Compiling with a GCC-compatible compiler")
 endif()
-
-add_executable(bin2h "bin2h.c")
-
-set_target_properties(bin2h PROPERTIES
-	C_STANDARD 90
-	C_STANDARD_REQUIRED ON
-	C_EXTENSIONS OFF
-)
-
 
 if (WARNINGS)
 	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))

--- a/bin2h/CMakeLists.txt
+++ b/bin2h/CMakeLists.txt
@@ -6,6 +6,30 @@ endif()
 
 project(bin2h LANGUAGES C)
 
+# Has to be placed after "project()"
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	# Using Clang (this is a match so that we also get "AppleClang" which is the Apple-provided Clang
+	set(COMPILER_IS_CLANG true)
+	message(STATUS "Compiling with clang")
+endif()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	# Using GCC
+	set(COMPILER_IS_GCC true)
+	message(STATUS "Compiling with gcc")
+endif()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+	# Using Intel C++
+	set(COMPILER_IS_ICC true)
+	message(STATUS "Compiling with ICC")
+endif()
+
+if (COMPILER_IS_CLANG OR COMPILER_IS_GCC OR COMPILER_IS_ICC)
+	set(COMPILER_IS_GCC_COMPATIBLE true)
+	message(STATUS "Compiling with a GCC-compatible compiler")
+endif()
+
 add_executable(bin2h "bin2h.c")
 
 set_target_properties(bin2h PROPERTIES
@@ -13,6 +37,63 @@ set_target_properties(bin2h PROPERTIES
 	C_STANDARD_REQUIRED ON
 	C_EXTENSIONS OFF
 )
+
+
+if (WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		# Force to always compile with /W4 on MSVC
+
+		# Can't do this with target_compile_options
+		# if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		# 	string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		# else()
+		# 	target_compile_options(CSE2 PRIVATE /W4)
+		# endif()
+
+		target_compile_options(bin2h PRIVATE /W4)
+	elseif(COMPILER_IS_GCC_COMPATIBLE)
+		target_compile_options(bin2h PRIVATE -Wall -Wextra -pedantic)
+	else()
+		message(WARNING "Could not activate warnings ! (Unsupported compiler)")
+	endif()
+endif()
+
+if (ALL_WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		# Force to always compile with /Wall on MSVC
+
+		# Can't do this with target_compile_options
+		# if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		# 	string(REGEX REPLACE "/W[0-4]" "/Wall" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		# else()
+		# 	target_compile_options(CSE2 PRIVATE /Wall)
+		# endif()
+
+		target_compile_options(bin2h PRIVATE /Wall)
+	elseif(COMPILER_IS_CLANG)
+		target_compile_options(bin2h PRIVATE -Weverything)
+	else()
+		message(WARNING "Could not activate all warnings ! (Unsupported compiler)")
+	endif()
+endif()
+
+if (FATAL_WARNINGS)
+	# HACK : Replace this with CMake provided stuff when possible (when CMake makes avoiding this possible (it isn't currently))
+
+	if (MSVC)
+		target_compile_options(CSE2 PRIVATE /WX)
+		target_compile_options(bin2h PRIVATE /WX)
+	elseif(COMPILER_IS_GCC_COMPATIBLE)
+		target_compile_options(CSE2 PRIVATE -Werror)
+		target_compile_options(bin2h PRIVATE -Werror)
+	else()
+		message(WARNING "Could not activate fatal warnings ! (Unsupported compiler)")
+	endif()
+endif()
 
 # MSVC tweak
 if(MSVC)

--- a/bin2h/CMakeLists.txt
+++ b/bin2h/CMakeLists.txt
@@ -14,20 +14,22 @@ set_target_properties(bin2h PROPERTIES
 	C_EXTENSIONS OFF
 )
 
+message(STATUS "Compiler ID : ${CMAKE_C_COMPILER_ID}")
+
 # Has to be placed after "project()"
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
 	# Using Clang (this is a match so that we also get "AppleClang" which is the Apple-provided Clang
 	set(COMPILER_IS_CLANG true)
 	message(STATUS "Compiling with clang")
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
 	# Using GCC
 	set(COMPILER_IS_GCC true)
 	message(STATUS "Compiling with gcc")
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+if (CMAKE_C_COMPILER_ID STREQUAL "Intel")
 	# Using Intel C++
 	set(COMPILER_IS_ICC true)
 	message(STATUS "Compiling with ICC")


### PR DESCRIPTION
This adds the WARNINGS, ALL_WARNINGS and FATAL_WARNINGS options that may be turned on or off to use warnings. Works with bin2h too, and shouldn't activate any warnings in the dependencies