### PR TITLE
Make MSVC recognize source files as UTF-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,9 @@ if(MSVC)
 	target_compile_definitions(CSE2 PRIVATE _CRT_SECURE_NO_WARNINGS)	# Disable warnings that normally fire up on MSVC when using "unsafe" functions instead of using MSVC's "safe" _s functions
 endif()
 
+# Make it so source files are recognized as UTF-8 by MSVC
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # Build bin2h externally, so it isn't cross-compiled when CSE2 is (Emscripten, cross-GCC, MinGW on Linux, etc.)
 include(ExternalProject)
 

--- a/DoConfig/CMakeLists.txt
+++ b/DoConfig/CMakeLists.txt
@@ -20,6 +20,9 @@ if(MSVC)
 	target_compile_definitions(DoConfig PRIVATE _CRT_SECURE_NO_WARNINGS)	# Disable warnings that normally fire up on MSVC when using "unsafe" functions instead of using MSVC's "safe" _s functions
 endif()
 
+# Make it so source files are recognized as UTF-8 by MSVC
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # Find FLTK
 if(NOT FORCE_LOCAL_LIBS)
 	set(FLTK_SKIP_FLUID ON)	# Do not require fltk-fluid (the UI designer)

--- a/bin2h/CMakeLists.txt
+++ b/bin2h/CMakeLists.txt
@@ -19,6 +19,9 @@ if(MSVC)
 	target_compile_definitions(bin2h PRIVATE _CRT_SECURE_NO_WARNINGS)	# Disable warnings that normally fire up on MSVC when using "unsafe" functions instead of using MSVC's "safe" _s functions
 endif()
 
+# Make it so source files are recognized as UTF-8 by MSVC
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # Enable link-time optimisation if available
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 	if((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9))


### PR DESCRIPTION
This fixes the compile on MSVC (which was broken for a while)