### PR TITLE
Remove undefs in WindowsWrapper

### DIFF
--- a/src/WindowsWrapper.h
+++ b/src/WindowsWrapper.h
@@ -1,10 +1,6 @@
 #pragma once
 
 #include <windows.h>
-// Avoid name collisions
-#undef DrawText
-#undef FindResource
-#undef CreateWindow
 
 #define SET_RECT(rect, l, t, r, b) \
 	rect.left = l; \


### PR DESCRIPTION
These undefs make no sense, as there is no name collision as far as I can check (grepping for the three names yields no results)