### PR TITLE
Make cmp usage clearer

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -31,7 +31,7 @@ BOOL LoadConfigData(CONFIG *conf)
 	fclose(fp);
 
 	// Check if version is not correct, and return if it failed
-	if (fread_result != 1 || strcmp(conf->proof, config_magic))
+	if (fread_result != 1 || strcmp(conf->proof, config_magic) != 0)
 	{
 		memset(conf, 0, sizeof(CONFIG));
 		return FALSE;

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -41,7 +41,7 @@ BOOL LoadMapData2(const char *path_map)
 	char check[3];
 	fread(check, 1, 3, fp);
 
-	if (memcmp(check, code_pxma, 3))
+	if (memcmp(check, code_pxma, 3) != 0)
 	{
 		fclose(fp);
 		return FALSE;

--- a/src/NpChar.cpp
+++ b/src/NpChar.cpp
@@ -68,7 +68,7 @@ BOOL LoadEvent(const char *path_event)
 	// Read "PXE" check
 	char code[4];
 	fread(code, 1, 4, fp);
-	if (memcmp(code, gPassPixEve, 3))
+	if (memcmp(code, gPassPixEve, 3) != 0)
 	{
 #ifdef FIX_BUGS
 		// The original game forgot to close the file here

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -104,7 +104,7 @@ BOOL LoadProfile(const char *name)
 
 	// Check header code
 	fread(profile.code, 8, 1, fp);
-	if (memcmp(profile.code, gProfileCode, 8))
+	if (memcmp(profile.code, gProfileCode, 8) != 0)
 	{
 #ifdef FIX_BUGS
 		fclose(fp);	// The original game forgets to close the file


### PR DESCRIPTION
Using `!= 0` makes it clearer we're searching for a difference here. Hopefully should keep ASM-accuracy, but I haven't checked