### PR TITLE
Draw : Fix surface_metadata.name's size

### DIFF
--- a/src/Draw.cpp
+++ b/src/Draw.cpp
@@ -44,7 +44,7 @@ static FontObject *font;
 // This doesn't exist in the Linux port, so none of these symbol names are accurate
 static struct
 {
-	char name[20];
+	char name[50];
 	unsigned int width;
 	unsigned int height;
 	SurfaceType type;


### PR DESCRIPTION
If this is not applied, the game crashes in `__strcpy_chk` with `-D_FORTIFY_SOURCE=2` (because `surface_metadata.size` is too small), which is enabled by certain distros such as Elementary OS. This is a very quick fix, I'll be working on a more permanent fix (that avoid fixed sized strings) soon