### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ language: cpp
 # Cache compiled object files with ccache
 cache: ccache
 
-osx_image: xcode11.2
+osx_image: xcode11.3
 
 compiler:
     - gcc


### PR DESCRIPTION
This is a PR for portable because while it fixes the build for enhanced, it still changes the XCode version, something that I'd rather not be inconsistent between branches. You'd need to merge portable into enhanced if you want to actually fix the build