### PR TITLE
Fix portable OpenGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,7 +527,7 @@ if(RENDERER MATCHES "OpenGL3")
 	target_include_directories(CSE2 PRIVATE "external/glad/include")
 
 	find_package(OpenGL REQUIRED)
-	target_link_libraries(CSE2 OpenGL::GL)
+	target_link_libraries(CSE2 OpenGL::GL ${CMAKE_DL_LIBS})
 endif()
 
 if(RENDERER MATCHES "OpenGLES2")


### PR DESCRIPTION
Right now, the portable branch with the OpenGL3 renderer fails to build, complaining about being unable to find some "dlopen" symbol. This PR aims to solve this