### PR TITLE
Backends/Rendering/SDLTexture: Solve -Wnarrowing warning

### DIFF
--- a/src/Backends/Rendering/SDLTexture.cpp
+++ b/src/Backends/Rendering/SDLTexture.cpp
@@ -312,7 +312,7 @@ void Backend_UnlockSurface(Backend_Surface *surface, unsigned int width, unsigne
 
 	free(surface->pixels);
 
-	SDL_Rect rect = {0, 0, width, height};
+	SDL_Rect rect = {0, 0, (int)width, (int)height};
 	SDL_UpdateTexture(surface->texture, &rect, buffer, width * 4);
 
 	free(buffer);


### PR DESCRIPTION
-Wnarrowing is enabled by default on gcc, and I'd rather not have a warning on every build without manually doing -Wno-narrowing