### PR TITLE
Fix build for mingw cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ set_target_properties(CSE2 PROPERTIES
 # Link libraries
 target_link_libraries(CSE2 PRIVATE ddraw dsound version shlwapi imm32 winmm dxguid gdi32)
 
-# Newer MSVC is missing `dinput.lib`, we need to use `dinput8.lib`
+# Newer MSVC is missing `dinput.lib`
 if(MSVC AND MSVC_VERSION GREATER_EQUAL 1500)
 	target_link_libraries(CSE2 PRIVATE dinput8)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,11 +245,11 @@ set_target_properties(CSE2 PROPERTIES
 ################
 
 # Link libraries
-target_link_libraries(CSE2 PRIVATE ddraw.lib dsound.lib version.lib shlwapi.lib imm32.lib winmm.lib dxguid.lib)
+target_link_libraries(CSE2 PRIVATE ddraw dsound version shlwapi imm32 winmm dxguid gdi32)
 
-# Newer MSVC is missing `dinput.lib`
+# Newer MSVC is missing `dinput.lib`, we need to use `dinput8.lib`
 if(MSVC AND MSVC_VERSION GREATER_EQUAL 1500)
-	target_link_libraries(CSE2 PRIVATE dinput8.lib)
+	target_link_libraries(CSE2 PRIVATE dinput8)
 else()
-	target_link_libraries(CSE2 PRIVATE dinput.lib)
+	target_link_libraries(CSE2 PRIVATE dinput)
 endif()


### PR DESCRIPTION
Using `.lib` resulted in the mingw linker failing to find the libraries. CMake documentation indicates that the non-`.lib` version should also work on MSVC : 

> The generated link line will ask the linker to search for the library (e.g. foo becomes -lfoo or foo.lib).
- [CMake documentation on target_link_libraries](https://cmake.org/cmake/help/latest/command/target_link_libraries.html)