### PR TITLE
Accurate: Change minimum CMake version from 3.12 to 3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10.2)
 
 
 #############


### PR DESCRIPTION
I have been able to confirm CSE2 accurate builds properly on Ubuntu 18.04 with CMake 3.10.2.