### PR TITLE
CMakeLists: Add minimum version for SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ endif()
 
 if(BACKEND_PLATFORM MATCHES "SDL2" OR BACKEND_AUDIO MATCHES "SDL2")
 	if(NOT FORCE_LOCAL_LIBS)
-		find_package(SDL2)
+		find_package(SDL2 2.0.6)
 
 		if (PKG_CONFIG_FOUND)
 			pkg_check_modules(sdl2 QUIET IMPORTED_TARGET sdl2)


### PR DESCRIPTION
CSE2 does not compile with a version of SDL2 before 2.0.6, so this enforces it directly in the CMakeLists